### PR TITLE
Linking to RcppEnsmallen and adding method headers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,6 @@ License: GPL (>= 2)
 Suggests: tinytest
 Depends: R (>= 3.5.0)
 Imports: Rcpp (>= 1.1.0)
-LinkingTo: Rcpp, RcppArmadillo, mlpack (>= 4.6.3)
+LinkingTo: Rcpp, RcppArmadillo, RcppEnsmallen, mlpack (>= 4.6.3)
 Encoding: UTF-8
 RoxygenNote: 7.3.2

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -3,6 +3,7 @@
 
 #include "../inst/include/rcppmlpackexamples_types.h"
 #include <RcppArmadillo.h>
+#include <RcppEnsmallen.h>
 #include <Rcpp.h>
 
 using namespace Rcpp;

--- a/src/kMeans.cpp
+++ b/src/kMeans.cpp
@@ -1,6 +1,5 @@
 
-#include <mlpack.h>             				// R package header provided by mlpack R package
-#include <mlpack.hpp>                           // mlpack C++ API
+#include <mlpack.h>  // R package header provided by mlpack R package
 #include <mlpack/methods/kmeans/kmeans.hpp> 	// particular algorithm used here
 
 //' Run a k-means clustering analysis, returning a list of cluster assignments
@@ -23,7 +22,7 @@
 Rcpp::List kMeans(const arma::mat& data, const int& clusters) {
 
     arma::Row<size_t> assignments; 		// to store results
-    mlpack::kmeans::KMeans<> k;    		// initialize with the default arguments.
+    mlpack::KMeans k;    	           	// initialize with the default arguments.
     k.Cluster(data, clusters, assignments);     // make call, filling 'assignments'
 
     return Rcpp::List::create(Rcpp::Named("clusters") = clusters,

--- a/src/linearRegression.cpp
+++ b/src/linearRegression.cpp
@@ -1,6 +1,5 @@
 
-#include <mlpack.h>             				// R package header provided by mlpack R package
-#include <mlpack.hpp>                           // mlpack C++ API
+#include <mlpack.h>  // R package header provided by mlpack R package
 #include <mlpack/methods/linear_regression/linear_regression.hpp> // particular algorithm used here
 
 //' Run a linear regression (with optional ridge regression)
@@ -33,7 +32,7 @@ arma::vec linearRegression(const arma::mat& matX,
                            const bool intercept = true) {
 
     arma::mat X = matX.t();     // account for arma/mlpack transposed view
-    mlpack::regression::LinearRegression<> lr(X, vecY, lambda, intercept);
+    mlpack::LinearRegression lr(X, vecY, lambda, intercept);
     arma::rowvec fittedValues(vecY.n_elem);
     lr.Predict(X,  fittedValues);
     return fittedValues.t();

--- a/src/loadDefaultPrediction.cpp
+++ b/src/loadDefaultPrediction.cpp
@@ -1,6 +1,6 @@
 
-#include <mlpack.h>             				// R package header provided by mlpack R package
-#include <mlpack.hpp>                           // mlpack C++ API
+#include <mlpack.h>  // R package header provided by mlpack R package
+#include <mlpack/methods/decision_tree/decision_tree.hpp> 	// particular algorithm used here
 // See https://github.com/mlpack/examples/blob/master/cpp/decision_tree/loan_default_prediction/
 
 using namespace mlpack;
@@ -101,7 +101,7 @@ Rcpp::List loanDefaultPrediction(arma::mat& loanDataFeatures,
      * mlpack.
      */
     // Create and train Decision Tree model using mlpack.
-    DecisionTree<> dt(Xtrain, Ytrain, 2);
+    DecisionTree dt(Xtrain, Ytrain, 2);
     // Classify the test set using trained model & get the probabilities.
     arma::Row<size_t> output;
     arma::mat probs;

--- a/src/randomForest.cpp
+++ b/src/randomForest.cpp
@@ -1,6 +1,7 @@
 
-#include <mlpack.h>             				// R package header provided by mlpack R package
-#include <mlpack.hpp>                           // mlpack C++ API
+#include <mlpack.h>  // R package header provided by mlpack R package
+#include <mlpack/methods/random_forest/random_forest.hpp> 	// particular algorithm used here
+
 
 //' Run a Random Forest Classifier
 //'
@@ -38,7 +39,7 @@ Rcpp::List randomForest(const arma::mat dataset, const arma::vec labels,
                         trainLabels, testLabels,
                         pct /* Percentage of dataset to use for test set. */);
 
-    mlpack::RandomForest<> rf(trainSet, trainLabels,
+    mlpack::RandomForest rf(trainSet, trainLabels,
                               nclasses /* Number of classes in dataset */,
                               ntrees /* number of trees */);
     // Predict the labels of the test points.,


### PR DESCRIPTION
This PR is for testing only and part of [3989](https://github.com/mlpack/mlpack/issues/3989) discussion.

Key changes:
- Added `RcppEnsmallen` to `LinkingTo`
- Added  method headers

``` r
library(rcppmlpackexamples)
suppressMessages(library(utils))
data("trees", package="datasets")
X <- with(trees, cbind(log(Girth), log(Height)))
y <- with(trees, log(Volume))
lmfit <- lm(y ~ X)
# summary(fitted(lmfit))
mlfit <- linearRegression(X, y)
# summary(mlfit)
all.equal(unname(fitted(lmfit)),  as.vector(mlfit))
#> [1] TRUE
```

R version 4.4.3 (2025-02-28 ucrt) / (GCC) 13.2.0
Platform: x86_64-w64-mingw32/x64
Running under: Windows 10 x64 (build 19045)

Passes R CMD Check.